### PR TITLE
Feature/modbus properties

### DIFF
--- a/src/main/java/live/ioteatime/ruleengine/controller/ConfigController.java
+++ b/src/main/java/live/ioteatime/ruleengine/controller/ConfigController.java
@@ -27,9 +27,9 @@ public class ConfigController {
         return ResponseEntity.ok("create mqtt Bridge properties ");
     }
 
-    @GetMapping("/delete/{bridgeName}")
-    public ResponseEntity<String> deleteBridge(@PathVariable String bridgeName) throws CreateJSchSessionException {
-        jschService.deleteBridge(bridgeName);
+    @GetMapping("/delete/{type}/{bridgeName}")
+    public ResponseEntity<String> deleteBridge(@PathVariable(name = "type")String type,@PathVariable String bridgeName) throws CreateJSchSessionException {
+        jschService.deleteBridge(type,bridgeName);
 
         return ResponseEntity.ok("Delete Bridge ");
     }

--- a/src/main/java/live/ioteatime/ruleengine/controller/ConfigController.java
+++ b/src/main/java/live/ioteatime/ruleengine/controller/ConfigController.java
@@ -1,5 +1,6 @@
 package live.ioteatime.ruleengine.controller;
 
+import live.ioteatime.ruleengine.domain.ModbusInfo;
 import live.ioteatime.ruleengine.domain.MqttInfo;
 import live.ioteatime.ruleengine.exception.CreateJSchSessionException;
 import live.ioteatime.ruleengine.service.CreateProperties;
@@ -21,9 +22,9 @@ public class ConfigController {
         String filePath = createProperties.createConfig(mqttInfo);
         log.info("addBroker file:{}", filePath);
 
-        jschService.scpFile(filePath, mqttInfo.getMqttId());
+        jschService.scpFile(filePath, mqttInfo.getMqttId(),"mqtt");
 
-        return ResponseEntity.ok("Create Properties ");
+        return ResponseEntity.ok("create mqtt Bridge properties ");
     }
 
     @GetMapping("/delete/{bridgeName}")
@@ -31,6 +32,16 @@ public class ConfigController {
         jschService.deleteBridge(bridgeName);
 
         return ResponseEntity.ok("Delete Bridge ");
+    }
+
+    @PostMapping("/modbus")
+    public ResponseEntity<String> addModbus(@RequestBody ModbusInfo modbusInfo) throws CreateJSchSessionException {
+        String filePath = createProperties.createConfig(modbusInfo);
+        log.info("addModbus file:{}", filePath);
+
+        jschService.scpFile(filePath,modbusInfo.getName(),"modbus");
+
+        return ResponseEntity.ok("create modbus Bridge properties ");
     }
 
 }

--- a/src/main/java/live/ioteatime/ruleengine/domain/ModbusInfo.java
+++ b/src/main/java/live/ioteatime/ruleengine/domain/ModbusInfo.java
@@ -1,0 +1,15 @@
+package live.ioteatime.ruleengine.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ModbusInfo {
+    private String name;
+    private String host;
+    private int port;
+    private String channel;
+}
+

--- a/src/main/java/live/ioteatime/ruleengine/domain/MqttInfo.java
+++ b/src/main/java/live/ioteatime/ruleengine/domain/MqttInfo.java
@@ -1,11 +1,12 @@
 package live.ioteatime.ruleengine.domain;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class MqttInfo {
     private String mqttHost;

--- a/src/main/java/live/ioteatime/ruleengine/service/CreateProperties.java
+++ b/src/main/java/live/ioteatime/ruleengine/service/CreateProperties.java
@@ -1,8 +1,21 @@
 package live.ioteatime.ruleengine.service;
 
+import live.ioteatime.ruleengine.domain.ModbusInfo;
 import live.ioteatime.ruleengine.domain.MqttInfo;
 
 public interface CreateProperties {
 
+    /**
+     *  mqtt bridge 생성 메소드
+     * @param mqttInfo 브릿지 생성을 위한 데이터
+     * @return 만들어진 설정파일 경로
+     */
     String createConfig(MqttInfo mqttInfo);
+
+    /**
+     *  modbus bridge 생성 메소드
+     * @param modbus 브릿지 생성을 위한 데이터
+     * @return 먼들어진 설정파일 경로
+     */
+    String createConfig(ModbusInfo modbus);
 }

--- a/src/main/java/live/ioteatime/ruleengine/service/JschService.java
+++ b/src/main/java/live/ioteatime/ruleengine/service/JschService.java
@@ -4,9 +4,10 @@ import live.ioteatime.ruleengine.exception.CreateJSchSessionException;
 
 public interface JschService {
 
-    /**
+    /** 목적지 인스턴스에 설정 파일을 scp 하는 메소드
      * @param filePath 보낼 파일의 경로
      * @param fileName 저장할 인스턴스의 디렉토리의 이름
+     * @param type 설정파일의 타입
      */
     void scpFile(String filePath, String fileName,String type) throws CreateJSchSessionException;
 
@@ -15,5 +16,5 @@ public interface JschService {
      * @param bridgeName 삭제할 브릿지 이름
      * @throws CreateJSchSessionException 에러
      */
-    void deleteBridge(String bridgeName) throws CreateJSchSessionException;
+    void deleteBridge(String type,String bridgeName) throws CreateJSchSessionException;
 }

--- a/src/main/java/live/ioteatime/ruleengine/service/JschService.java
+++ b/src/main/java/live/ioteatime/ruleengine/service/JschService.java
@@ -8,7 +8,7 @@ public interface JschService {
      * @param filePath 보낼 파일의 경로
      * @param fileName 저장할 인스턴스의 디렉토리의 이름
      */
-    void scpFile(String filePath, String fileName) throws CreateJSchSessionException;
+    void scpFile(String filePath, String fileName,String type) throws CreateJSchSessionException;
 
     /**
      *  bridge 제거 메소드

--- a/src/main/java/live/ioteatime/ruleengine/service/impl/CreatePropertiesImpl.java
+++ b/src/main/java/live/ioteatime/ruleengine/service/impl/CreatePropertiesImpl.java
@@ -1,5 +1,6 @@
 package live.ioteatime.ruleengine.service.impl;
 
+import live.ioteatime.ruleengine.domain.ModbusInfo;
 import live.ioteatime.ruleengine.domain.MqttInfo;
 import live.ioteatime.ruleengine.service.CreateProperties;
 import lombok.RequiredArgsConstructor;
@@ -34,20 +35,44 @@ public class CreatePropertiesImpl implements CreateProperties {
 
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
             writer.write("spring.config.name=prod" + "\n");
+            writer.write("bridge.mod=mqtt" + "\n");
             writer.write("mqtt.server.uri=" + mqttInfo.getMqttHost() + "\n");
             writer.write("mqtt.client.id=" + mqttInfo.getMqttId() + "\n");
             writer.write("mqtt.subscribe.topic=" + splitTopic(mqttInfo.getMqttTopic()) + "\n");
-            writer.write("spring.rabbitmq.host=" + rabbitProperties.getHost() + "\n");
-            writer.write("spring.rabbitmq.port=" + rabbitProperties.getPort() + "\n");
-            writer.write("spring.rabbitmq.username=" + rabbitProperties.getUsername() + "\n");
-            writer.write("spring.rabbitmq.password=" + rabbitProperties.getPassword() + "\n");
-            writer.write("spring.rabbitmq.template.exchange=" + rabbitProperties.getTemplate().getExchange() + "\n");
-            writer.write("spring.rabbitmq.template.routing-key=" + rabbitProperties.getTemplate().getRoutingKey() + "\n");
+            rabbitmqConfigSet(writer);
         } catch (IOException e) {
-            log.error("Create FIle false {}", e.getMessage());
+            log.error("Create mqtt FIle false {}", e.getMessage());
         }
 
         return file.getPath();
+    }
+
+    @Override
+    public String createConfig(ModbusInfo modbus) {
+        String fileName = "application-prod.properties";
+        File file = new File(path + fileName);
+
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+            writer.write("spring.config.name=prod" + "\n");
+            writer.write("bridge.mod=modbus" + "\n");
+            writer.write("modbus.host=" + modbus.getHost() + "\n");
+            writer.write("modbus.port=" + modbus.getPort() + "\n");
+            writer.write("modbus.channels=" + modbus.getChannel() + "\n");
+            rabbitmqConfigSet(writer);
+        } catch (IOException e) {
+            log.error("Create modbus FIle false {}", e.getMessage());
+        }
+
+        return file.getPath();
+    }
+
+    private void rabbitmqConfigSet(BufferedWriter writer) throws IOException {
+        writer.write("spring.rabbitmq.host=" + rabbitProperties.getHost() + "\n");
+        writer.write("spring.rabbitmq.port=" + rabbitProperties.getPort() + "\n");
+        writer.write("spring.rabbitmq.username=" + rabbitProperties.getUsername() + "\n");
+        writer.write("spring.rabbitmq.password=" + rabbitProperties.getPassword() + "\n");
+        writer.write("spring.rabbitmq.template.exchange=" + rabbitProperties.getTemplate().getExchange() + "\n");
+        writer.write("spring.rabbitmq.template.routing-key=" + rabbitProperties.getTemplate().getRoutingKey() + "\n");
     }
 
     private String splitTopic(List<String> topics) {

--- a/src/main/java/live/ioteatime/ruleengine/service/impl/JschServiceImpl.java
+++ b/src/main/java/live/ioteatime/ruleengine/service/impl/JschServiceImpl.java
@@ -27,9 +27,9 @@ public class JschServiceImpl implements JschService {
     private final JSchManager jSchManager;
 
     @Override
-    public void scpFile(String filePath, String fileName) throws CreateJSchSessionException {
+    public void scpFile(String filePath, String fileName,String type) throws CreateJSchSessionException {
         String startShell = "./startup.sh ";
-        String destinationDir = jschProperties.getSavePath() + "/" + fileName;
+        String destinationDir = jschProperties.getSavePath()+type + "/" + fileName;
         Session session = jSchManager.createSession();
         ChannelSftp channelSftp = jSchManager.createChannelSftp(session);
         ChannelExec channelExec = jSchManager.createChannelExec(session);

--- a/src/main/java/live/ioteatime/ruleengine/service/impl/JschServiceImpl.java
+++ b/src/main/java/live/ioteatime/ruleengine/service/impl/JschServiceImpl.java
@@ -37,7 +37,7 @@ public class JschServiceImpl implements JschService {
         try {
             mkdirAndPut(filePath, channelSftp, destinationDir);
             deleteFile(filePath);
-            giveCommand(startShell, fileName, channelExec);
+            giveCommand(startShell, type, fileName, channelExec);
             scriptMessage(channelExec);
             jschDisconnect(session, channelSftp, channelExec);
         } catch (Exception e) {
@@ -46,15 +46,14 @@ public class JschServiceImpl implements JschService {
     }
 
     @Override
-    public void deleteBridge(String bridgeName) throws CreateJSchSessionException {
+    public void deleteBridge(String type,String bridgeName) throws CreateJSchSessionException {
         String stopShell = "./stop.sh ";
         Session session = jSchManager.createSession();
         ChannelExec channelExec = jSchManager.createChannelExec(session);
 
         try {
-            giveCommand(stopShell, bridgeName, channelExec);
+            giveCommand(stopShell, type,bridgeName, channelExec);
             scriptMessage(channelExec);
-
             channelExec.disconnect();
             session.disconnect();
             log.info("done");
@@ -123,8 +122,8 @@ public class JschServiceImpl implements JschService {
      * @param fileName    실행 시킬 스크립트 경로
      * @param channelExec commandline 채널
      */
-    private static void giveCommand(String command, String fileName, ChannelExec channelExec) throws JSchException {
-        channelExec.setCommand(command + fileName);
+    private static void giveCommand(String command,String type,String fileName, ChannelExec channelExec) throws JSchException {
+        channelExec.setCommand(command + type + " " + fileName);
         log.info("giveCommand {}", command + fileName);
         channelExec.connect();
     }

--- a/src/test/java/live/ioteatime/ruleengine/controller/ConfigControllerTest.java
+++ b/src/test/java/live/ioteatime/ruleengine/controller/ConfigControllerTest.java
@@ -65,14 +65,14 @@ class ConfigControllerTest {
 
     @Test
     void deleteBroker() throws Exception {
-        doNothing().when(jschService).deleteBridge(anyString());
+        doNothing().when(jschService).deleteBridge(anyString(),anyString());
 
         mockMvc.perform(get("/delete/{bridgeName}", "test")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("Delete Bridge ")));
 
-        verify(jschService).deleteBridge(anyString());
+        verify(jschService).deleteBridge(anyString(),anyString());
     }
 
     @Test

--- a/src/test/java/live/ioteatime/ruleengine/service/impl/CreatePropertiesImplTest.java
+++ b/src/test/java/live/ioteatime/ruleengine/service/impl/CreatePropertiesImplTest.java
@@ -1,5 +1,6 @@
 package live.ioteatime.ruleengine.service.impl;
 
+import live.ioteatime.ruleengine.domain.ModbusInfo;
 import live.ioteatime.ruleengine.domain.MqttInfo;
 import live.ioteatime.ruleengine.service.CreateProperties;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +11,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.File;
+import java.lang.reflect.Constructor;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,20 +35,38 @@ class CreatePropertiesImplTest {
         when(templateMock.getExchange()).thenReturn("testExchange");
         when(templateMock.getRoutingKey()).thenReturn("testRoutingKey");
 
-        createProperties =new CreatePropertiesImpl(rabbitPropertiesMock);
+        createProperties = new CreatePropertiesImpl(rabbitPropertiesMock);
     }
 
     @Test
-    void createConfig(){
-        MqttInfo mqttInfo = new MqttInfo();
-        List<String> topics = List.of("data/#","data/#","data/#");
+    void createMqttConfigTest() throws Exception {
+        Constructor<MqttInfo> constructor = MqttInfo.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        MqttInfo mqttInfo = constructor.newInstance();
+        List<String> topics = List.of("data/#", "data/#", "data/#");
         ReflectionTestUtils.setField(mqttInfo, "mqttHost", "localhost");
         ReflectionTestUtils.setField(mqttInfo, "mqttId", "test");
         ReflectionTestUtils.setField(mqttInfo, "mqttTopic", topics);
 
         String resultFilePath = createProperties.createConfig(mqttInfo);
-
         File resultFile = new File(resultFilePath);
+
+        assertTrue(resultFile.exists());
+    }
+
+    @Test
+    void createModbusConfigTest() throws Exception {
+        Constructor<ModbusInfo> constructor = ModbusInfo.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        ModbusInfo modbusInfo = constructor.newInstance();
+        ReflectionTestUtils.setField(modbusInfo, "name", "localhost");
+        ReflectionTestUtils.setField(modbusInfo, "host", "localhost");
+        ReflectionTestUtils.setField(modbusInfo, "port", 88);
+        ReflectionTestUtils.setField(modbusInfo, "channel", "800/2,12/21");
+
+        String config = createProperties.createConfig(modbusInfo);
+        File resultFile = new File(config);
+
         assertTrue(resultFile.exists());
     }
 

--- a/src/test/java/live/ioteatime/ruleengine/service/impl/JschServiceImplTest.java
+++ b/src/test/java/live/ioteatime/ruleengine/service/impl/JschServiceImplTest.java
@@ -46,13 +46,14 @@ class JschServiceImplTest {
             String fileName = "test";
             String command = "./startup.sh " + fileName;
             String destinationPaht = destination + "/" + fileName;
+            String type = "mqtt";
 
             when(properties.getSavePath()).thenReturn(destination);
             when(jSchManager.createSession()).thenReturn(session);
             when(jSchManager.createChannelSftp(session)).thenReturn(channelSftp);
             when(jSchManager.createChannelExec(session)).thenReturn(channelExec);
 
-            jschService.scpFile(filePath, fileName);
+            jschService.scpFile(filePath, fileName,type);
 
             verify(channelSftp).mkdir(eq(destinationPaht));
             verify(channelSftp).put(eq(filePath), eq(destinationPaht), eq(ChannelSftp.OVERWRITE));


### PR DESCRIPTION
브릿지 삭제 시 타입을 확인하고 삭제

기존 - properties 폴더에 모든 설정 파일이 존재 하여 설정 파일 이름 만 으로 삭제 가능
변경 - modbus, mqtt 폴더에 각각 프로퍼티 파일 존재 , 타입이 mobus , mqtt 확인 후 찾아가 제거